### PR TITLE
Taxon Improvements

### DIFF
--- a/assets/src/js/public/single/classification.js
+++ b/assets/src/js/public/single/classification.js
@@ -67,13 +67,13 @@
 
     // {{{ reset_taxa
     function reset_taxa() {
-            $.map(ranks, function(rank) {
+            $.map(ranks.slice(1, -1), function(rank) {
                 $('#fossil-taxon-' + rank).val("");
             });
         }
         // }}}
 
-    // {{{ save_taxon 
+    // {{{ save_taxon
     function save_taxon() {
             var nonce = $('#myfossil_specimen_nonce').val();
             var post_id = parseInt($('#post_id').val());
@@ -100,7 +100,7 @@
                     $('#fossil-taxon-success').show().fadeOut();
                     $('#edit-fossil-taxon-save-alert').fadeOut();
                     console.info(data);
-                     
+
 
                 },
                 complete: function(data) {

--- a/includes/models/FossilTaxa.php
+++ b/includes/models/FossilTaxa.php
@@ -145,17 +145,34 @@ class FossilTaxa extends Base
 
     public function __toString()
     {
-        $c = 0;
-        $str = "";
+        /*
+         * Show 3 ranks, starting with common name and then the most accurate
+         * ones
+         */
+        $N_RANKS = 3;
+
+        /**
+         * Lists the common name (if defined), and then the two most accurate
+         * ranks
+         */
+        $taxon_strs = [];
         foreach ( self::get_ranks() as $rank ) {
             if ( $this->{ sprintf( 'taxon_id_%s', $rank ) } > 0
-                && $this->{ $rank }->name && $c < 3) {
-                $str .= (string) $this->{ $rank } . "<br />";
-                $c++;
+                    && $this->{ $rank }->name) {
+                $taxon_strs[] = (string) $this->{ $rank };
             }
         }
+
+        $taxa = [];
+        while ( $taxon_strs && count( $taxa ) < $N_RANKS ) {
+            $taxa[] = array_pop( $taxon_strs );
+        };
+
+        $str = implode( array_reverse( $taxa ), "<br />" );
+
         if ( !$str )
             return '<span class="unknown">Unknown</span>';
+
         return $str;
     }
 }


### PR DESCRIPTION
Now the common name is not overwriten to null when the taxonomy helper popup is
used.

I think that there might should be an alert to say that the common name may no
longer be accurate once this is changed. If I have time, I'll try to add this
to the pull request.

Closes myfossil/myfossil-specimen#81